### PR TITLE
Add line length args to black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
+    args:
+      - '--line-length=79'
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
     rev: v3.2.0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python: 3.8.3
 install:
   - pip install -r requirements_dev.txt
 script:
-  - black --check .
+  - black --line-length=79 --check .
   - pytest
 env:
   - PYTHONBREAKPOINT=0


### PR DESCRIPTION
Add line length args to black in pre-commit and travis

.pre-commit-config.yaml:
  - args added with --line-length=79

.travis.yml:
  - command changed to add --line-length=79